### PR TITLE
Update Aside.jsx for typos

### DIFF
--- a/molecules/Aside/Aside.jsx
+++ b/molecules/Aside/Aside.jsx
@@ -106,8 +106,8 @@ function Aside({ css }) {
       header: <span className="h4">{t('launching')} Steam Rom Manager</span>,
       body: (
         <p>
-          We will close Steam if its running and then Steam Rom Manager will
-          open, this could take a few seconds, please wait.
+          We will close Steam if it's running, and then Steam Rom Manager will
+          open. This could take a few seconds, please wait.
         </p>
       ),
       footer: <ProgressBar css="progress--success" infinite max="100" />,
@@ -133,8 +133,8 @@ function Aside({ css }) {
         body: (
           <>
             <p>
-              We will close Steam if its running and then Steam Rom Manager will
-              open, this could take a few seconds, please wait.
+              We will close Steam if it's running, and then Steam Rom Manager will
+              open. This could take a few seconds, please wait.
             </p>
             <strong>
               Desktop controls will temporarily revert to touch/trackpad/L2/R2.

--- a/molecules/Aside/Aside.jsx
+++ b/molecules/Aside/Aside.jsx
@@ -106,7 +106,7 @@ function Aside({ css }) {
       header: <span className="h4">{t('launching')} Steam Rom Manager</span>,
       body: (
         <p>
-          We will close Steam if it's running, and then Steam Rom Manager will
+          We will close Steam if it's running and then Steam Rom Manager will
           open. This could take a few seconds, please wait.
         </p>
       ),
@@ -133,7 +133,7 @@ function Aside({ css }) {
         body: (
           <>
             <p>
-              We will close Steam if it's running, and then Steam Rom Manager will
+              We will close Steam if it's running and then Steam Rom Manager will
               open. This could take a few seconds, please wait.
             </p>
             <strong>


### PR DESCRIPTION
The text had `its` when it should be `it's`. We also split the run-on sentence into two sentences.